### PR TITLE
fix: move client setup code into init method

### DIFF
--- a/feo/client/api/base.py
+++ b/feo/client/api/base.py
@@ -1,7 +1,6 @@
-from abc import ABC
-
-from .client import client
+from .client import Client
 
 
-class BaseAPI(ABC):
-    client = client
+class BaseAPI:
+    def __init__(self):
+        self.client = Client()

--- a/feo/client/api/client.py
+++ b/feo/client/api/client.py
@@ -7,33 +7,31 @@ from feo.client.auth import login
 
 
 class Client:
-    token_path = os.environ.get(
-        "FEO_TOKEN_PATH",
-        os.path.join(os.path.expanduser("~"), ".tz-feo", "token.json"),
-    )
-
-    if os.path.exists(token_path):
-        token = json.load(open(token_path))
-
-    else:
-        login()
-        token = json.load(open(token_path))
-
-    headers = {"Authorization": "Bearer {}".format(token["access_token"])}
-
-    base_url = (
-        os.environ.get("FEO_API_URL", "https://api.feo.transitionzero.org")
-        + "/"
-        + os.environ.get("FEO_API_VERSION", "v1")
-    )
-    httpx_client = httpx.Client(
-        base_url=base_url,
-        headers=headers,
-        timeout=10,
-    )
-
     def __init__(self):
-        pass
+        self.token_path = os.environ.get(
+            "FEO_TOKEN_PATH",
+            os.path.join(os.path.expanduser("~"), ".tz-feo", "token.json"),
+        )
+
+        if os.path.exists(self.token_path):
+            self.token = json.load(open(self.token_path))
+
+        else:
+            login()
+            self.token = json.load(open(self.token_path))
+
+        self.headers = {"Authorization": "Bearer {}".format(self.token["access_token"])}
+
+        self.base_url = (
+            os.environ.get("FEO_API_URL", "https://api.feo.transitionzero.org")
+            + "/"
+            + os.environ.get("FEO_API_VERSION", "v1")
+        )
+        self.httpx_client = httpx.Client(
+            base_url=self.base_url,
+            headers=self.headers,
+            timeout=10,
+        )
 
     def get(self, *args, **kwargs):
         return self.httpx_client.get(*args, **kwargs)
@@ -44,6 +42,3 @@ class Client:
     @classmethod
     def catch_errors(cls, r):
         r.raise_for_status()
-
-
-client = Client()


### PR DESCRIPTION
### Description

**Non-urgent**

Resolves #18

Client setup code (including auth) now only runs at init time, not import time.

### Checklist
- [x] Dependencies install correctly in a clean environment and code executes;
- [x] Test coverage extended; created tests fail without the change (if possible);
- [x] All tests passing;
- [x] Commits follow a type convention (e.g. https://gist.github.com/brianclements/841ea7bffdb01346392c#type);
- [x] Extended the README, documentation and/or docstrings, if necessary;
