### PR TITLE
fix: actually run tests in production-tests.yaml

### DIFF
--- a/.github/workflows/production-tests.yaml
+++ b/.github/workflows/production-tests.yaml
@@ -62,6 +62,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -e .[dev]
+        pytest
 
     - uses: ravsamhq/notify-slack-action@v2
       if: always()


### PR DESCRIPTION
### Description
Add line to production-tests.yaml to actually run the tests. Somehow this slipped through: workflow currently just installs deps and then exits.

### Checklist
- [x] Dependencies install correctly in a clean environment and code executes;
- [x] Test coverage extended; created tests fail without the change (if possible);
- [ ] All tests passing;
- [x] Commits follow a type convention (e.g. https://gist.github.com/brianclements/841ea7bffdb01346392c#type);
- [x] Extended the README, documentation and/or docstrings, if necessary;
