### PR TITLE
Fix: removed time filter test on technology

### DIFF
--- a/tests/CI/test_technology.py
+++ b/tests/CI/test_technology.py
@@ -22,11 +22,5 @@ def test_technology_projections():
     gas_combined_cycle = Technology.from_id("combined-cycle-gas-turbine")
     assert isinstance(gas_combined_cycle.projections, RecordCollection)
     assert len(gas_combined_cycle.projections) > 0
-    print(gas_combined_cycle.projections.valid_timestamp_start)
-    after_2040 = gas_combined_cycle.projections.loc[
-        gas_combined_cycle.projections.valid_timestamp_start > "2030-01-01"
-    ]
-    assert len(after_2040) > 0
-
     record = gas_combined_cycle.projections.iloc[0].to_records()
     assert isinstance(record, Record)


### PR DESCRIPTION
### Description
Removes an unnecessary test that checks whether return technology records have a `valid_timestamp_start` above a certain data.
 
### Checklist
- [x] Dependencies install correctly in a clean environment and code executes;
- [x] Test coverage extended; created tests fail without the change (if possible);
- [x] All tests passing;
- [x] Commits follow a type convention (e.g. https://gist.github.com/brianclements/841ea7bffdb01346392c#type);
- [x] Extended the README, documentation and/or docstrings, if necessary;
