### PR TITLE
Fix: Client Timeout Length

### DIFF
--- a/feo/client/api/client.py
+++ b/feo/client/api/client.py
@@ -29,7 +29,7 @@ class Client:
     httpx_client = httpx.Client(
         base_url=base_url,
         headers=headers,
-        timeout=10,
+        timeout=30,
     )
 
     def __init__(self):


### PR DESCRIPTION
### Description

Increases the client timeout length to 30 seconds.

### Checklist
- [x] Dependencies install correctly in a clean environment and code executes;
- [x] Test coverage extended; created tests fail without the change (if possible);
- [x] All tests passing;
- [x] Commits follow a type convention (e.g. https://gist.github.com/brianclements/841ea7bffdb01346392c#type);
- [x] Extended the README, documentation and/or docstrings, if necessary;
