### PR TITLE
[ENG-415]Fix/login repeat

### DIFF
--- a/feo/client/api/client.py
+++ b/feo/client/api/client.py
@@ -1,11 +1,18 @@
 import os
+import threading
+from typing import Generator
 
 import httpx
+from httpx._models import Request, Response
 
 from feo.client.api.schemas import AuthToken
-from feo.client.auth import AUTH0_CLIENT_ID, AUTH0_DOMAIN, TOKEN_PATH, login
+from feo.client.auth import AUTH0_CLIENT_ID, AUTH0_DOMAIN, TOKEN_PATH
 
 CLIENT_TIMEOUT = 10
+
+
+class RefreshTokenError(Exception):
+    pass
 
 
 class ClientAuth(httpx.Auth):
@@ -13,19 +20,25 @@ class ClientAuth(httpx.Auth):
 
     def __init__(self):
         self.token_path = TOKEN_PATH
+        self.token = None
+        self._sync_lock = threading.RLock()
 
-    def _parse_token_file(self, token_file):
-        try:
-            self.token = AuthToken.from_file(self.token_path)
-        except FileNotFoundError:
-            raise FileNotFoundError(
-                f"No token file found at path '{self.token_path}'. Please login."
-            )
+    def get_token(self):
+        with self._sync_lock:
+            if self.token is None:
+                try:
+                    self.token = AuthToken.from_file(self.token_path)
+                except FileNotFoundError:
+                    raise FileNotFoundError(
+                        f"No token file found at path '{self.token_path}'. Please login."
+                    ) from None
 
     def _parse_token_response(self, token_response):
+        if token_response.status_code == 403:
+            raise RefreshTokenError("Token refresh failed. Please login again.")
         self.token = AuthToken(**token_response.json())
 
-    def _refresh_token_resquest(self):
+    def _refresh_token_request(self):
         token_payload = {
             "grant_type": "refresh_token",
             "client_id": AUTH0_CLIENT_ID,
@@ -34,24 +47,18 @@ class ClientAuth(httpx.Auth):
 
         return httpx.Request("POST", f"https://{AUTH0_DOMAIN}/oauth/token", data=token_payload)
 
-    def auth_flow(self, request):
-        if self.token is None:
-            try:
-                self._parse_token_file(self.token_path)
-            except FileNotFoundError:
-                login()
+    def sync_auth_flow(self, request: Request) -> Generator[Request, Response, None]:
+        self.get_token()
+        request.headers.update({"Authorization": f"Bearer {self.token.access_token}"})
+        response = yield request
 
-        else:
+        if response.status_code == 401:
+            print("possible expired token")
+            refresh_response = yield self._refresh_token_request()
+            self._parse_token_response(refresh_response)
+
             request.headers.update({"Authorization": f"Bearer {self.token.access_token}"})
-            response = yield request
-
-            if response.status_code == 401:
-                # possible expired token
-                refresh_response = yield self.refresh_token_resquest()
-                self._parse_token_response(refresh_response)
-
-                request.headers.update({"Authorization": f"Bearer {self.token.access_token}"})
-                yield request
+            yield request
 
 
 class Client:

--- a/feo/client/api/client.py
+++ b/feo/client/api/client.py
@@ -9,6 +9,8 @@ from feo.client.api.schemas import AuthToken
 from feo.client.auth import AUTH0_CLIENT_ID, AUTH0_DOMAIN, TOKEN_PATH
 
 CLIENT_TIMEOUT = 10
+LOGIN_EXAMPLE = """from feo.client.auth import login
+login()"""
 
 
 class RefreshTokenError(Exception):
@@ -33,7 +35,8 @@ class ClientAuth(httpx.Auth):
                     self.token = AuthToken.from_file(self.token_path)
                 except FileNotFoundError:
                     raise FileNotFoundError(
-                        f"No token file found at path '{self.token_path}'. Please login."
+                        f"No token file found at path '{self.token_path}'."
+                        f" Please login e.g. \n{LOGIN_EXAMPLE}"
                     )
 
     def _parse_token_response(self, token_response):

--- a/feo/client/api/client.py
+++ b/feo/client/api/client.py
@@ -3,7 +3,32 @@ import os
 
 import httpx
 
+from feo.client.api.schemas import AuthToken
 from feo.client.auth import login
+
+
+class MissingAuthError(BaseException):
+    pass
+
+
+class Auth:
+    DEFAULT_TOKEN_PATH = os.path.join(os.path.expanduser("~"), ".tz-feo", "token.json")
+    DEFAULT_TOKEN_ENV = "FEO_TOKEN_PATH"  # nosec
+
+    def __init__(self):
+        self.token_path = os.environ.get(self.DEFAULT_TOKEN_ENV, self.DEFAULT_TOKEN_PATH)
+
+        self.token = None
+
+    def authorize(self):
+        login()
+        self.token = AuthToken.from_file(self.token_path)
+
+    def to_header(self):
+        if self.token is None:
+            self.authorize()
+
+        return {"Authorization": f"Bearer {self.token.access_token}"}
 
 
 class Client:
@@ -19,7 +44,10 @@ class Client:
         login()
         token = json.load(open(token_path))
 
-    headers = {"Authorization": "Bearer {}".format(token["access_token"])}
+    headers = {
+        "Authorization": "Bearer {}".format(token["access_token"]),
+        "user-agent": "feo-client",
+    }
 
     base_url = (
         os.environ.get("FEO_API_URL", "https://api.feo.transitionzero.org")
@@ -31,6 +59,12 @@ class Client:
         headers=headers,
         timeout=10,
     )
+
+    def _add_auth(self, func):
+        pass
+
+    def _parse_token(self):
+        pass
 
     def __init__(self):
         pass

--- a/feo/client/api/client.py
+++ b/feo/client/api/client.py
@@ -64,7 +64,7 @@ class ClientAuth(httpx.Auth):
         token_json = token_response.json()
         if token_response.status_code == 403:
             raise RefreshTokenError(
-                f"{token_response['error_description']}." f" Please login e.g. \n{LOGIN_EXAMPLE}"
+                f"{token_json['error_description']}." f" Please login e.g. \n{LOGIN_EXAMPLE}"
             )
         self.token = AuthToken(**token_json)
 

--- a/feo/client/api/client.py
+++ b/feo/client/api/client.py
@@ -34,7 +34,7 @@ class ClientAuth(httpx.Auth):
                 except FileNotFoundError:
                     raise FileNotFoundError(
                         f"No token file found at path '{self.token_path}'. Please login."
-                    ) from None
+                    )
 
     def _parse_token_response(self, token_response):
         if token_response.status_code == 403:

--- a/feo/client/api/client.py
+++ b/feo/client/api/client.py
@@ -63,9 +63,8 @@ class ClientAuth(httpx.Auth):
         token_response.read()
         token_json = token_response.json()
         if token_response.status_code == 403:
-            raise RefreshTokenError(
-                f"{token_json['error_description']}." f" Please login e.g. \n{LOGIN_EXAMPLE}"
-            )
+            err_description = token_json.get("error_description", "No additional information")
+            raise RefreshTokenError(f"{err_description}. Please login e.g. \n{LOGIN_EXAMPLE}")
         self.token = AuthToken(**token_json)
 
     def _refresh_token_request(self) -> httpx.Request:

--- a/feo/client/api/schemas.py
+++ b/feo/client/api/schemas.py
@@ -467,5 +467,5 @@ class AuthToken(BaseModel):
     @classmethod
     def from_file(cls, file_path):
         with open(file_path) as f:
-            token_dict = json.load(f.read())
+            token_dict = json.load(f)
         return cls(**token_dict)

--- a/feo/client/api/schemas.py
+++ b/feo/client/api/schemas.py
@@ -501,7 +501,7 @@ class TechnologyQueryResponse(PydanticBaseModel):
 
 class AuthToken(BaseModel):
     access_token: str
-    refresh_token: str
+    refresh_token: str = ""
     id_token: str
     scope: str
     expires_in: int

--- a/feo/client/api/schemas.py
+++ b/feo/client/api/schemas.py
@@ -1,3 +1,4 @@
+import json
 from datetime import date, datetime
 from typing import Annotated, Any, Dict, List, Literal, Optional, Tuple, Union
 from warnings import warn
@@ -453,3 +454,18 @@ class TechnologyQueryResponse(PydanticBaseModel):
     technologies: list[Technology] = Field(..., title="Technologies")
     page: int | None = Field(None, title="Page")
     total_pages: int | None = Field(None, title="Total Pages")
+
+
+class AuthToken(BaseModel):
+    access_token: str
+    refresh_token: str
+    id_token: str
+    scope: str
+    expires_in: int
+    token_type: str
+
+    @classmethod
+    def from_file(cls, file_path):
+        with open(file_path) as f:
+            token_dict = json.load(f.read())
+        return cls(**token_dict)

--- a/feo/client/auth.py
+++ b/feo/client/auth.py
@@ -10,6 +10,9 @@ AUTH0_CLIENT_ID = os.environ.get("AUTH0_CLIENT_ID", "HhT6aGS8u3Pg4PkVQ8sKUtnrtg0
 AUTH0_DOMAIN = os.environ.get("AUTH0_DOMAIN", "prod-feo-tz.eu.auth0.com")
 AUTH0_AUDIENCE = os.environ.get("AUTH0_AUDIENCE", "https://api.feo.transitionzero.org")
 ALGORITHMS = ["RS256"]
+DEFAULT_TOKEN_PATH = os.path.join(os.path.expanduser("~"), ".tz-feo", "token.json")
+DEFAULT_TOKEN_ENV = "FEO_TOKEN_PATH"  # nosec
+TOKEN_PATH = os.environ.get(DEFAULT_TOKEN_ENV, DEFAULT_TOKEN_PATH)
 
 
 def login(config=None):
@@ -18,11 +21,7 @@ def login(config=None):
     to a new hidden folder in the $HOME directory
     """
 
-    token_dir = os.path.join(os.path.expanduser("~"), ".tz-feo")
-
-    if not os.path.exists(token_dir):
-        logger.info(f"Writing token directory {token_dir}")
-        os.makedirs(token_dir)
+    os.makedirs(os.path.dirname(TOKEN_PATH), exist_ok=True)
 
     device_code_payload = {
         "client_id": AUTH0_CLIENT_ID,
@@ -31,7 +30,9 @@ def login(config=None):
     }
 
     device_code_response = requests.post(
-        f"https://{AUTH0_DOMAIN}/oauth/device/code", json=device_code_payload, timeout=30  # noqa
+        f"https://{AUTH0_DOMAIN}/oauth/device/code",
+        json=device_code_payload,
+        timeout=30,  # noqa
     )
     device_code_response.raise_for_status()
 
@@ -55,7 +56,9 @@ def login(config=None):
     print("Checking for authentication", end="")
     while not authenticated:
         token_response = requests.post(
-            f"https://{AUTH0_DOMAIN}/oauth/token", data=token_payload, timeout=30  # noqa
+            f"https://{AUTH0_DOMAIN}/oauth/token",
+            data=token_payload,
+            timeout=30,  # noqa
         )
 
         token_data = token_response.json()
@@ -75,7 +78,25 @@ def login(config=None):
     # display a friendly welcome... print ('Hello {name}!')
 
     # write token data to file
-    json.dump(
-        token_data,
-        open(os.path.join(os.path.expanduser("~"), ".tz-feo", "token.json"), "w"),
+    save_token(token_data, TOKEN_PATH)
+
+
+def refresh(refresh_token):
+    token_payload = {
+        "grant_type": "refresh_token",
+        "client_id": AUTH0_CLIENT_ID,
+        "refresh_token": refresh_token,
+    }
+
+    token_response = requests.post(
+        f"https://{AUTH0_DOMAIN}/oauth/token", data=token_payload, timeout=30  # noqa
     )
+    token_response.raise_for_status()
+    token_data = token_response.json()
+
+    save_token(token_data, TOKEN_PATH)
+
+
+def save_token(token_data, token_path):
+    with open(token_path, "w") as tf:
+        json.dump(token_data, tf)

--- a/feo/client/auth.py
+++ b/feo/client/auth.py
@@ -78,25 +78,5 @@ def login(config=None):
     # display a friendly welcome... print ('Hello {name}!')
 
     # write token data to file
-    save_token(token_data, TOKEN_PATH)
-
-
-def refresh(refresh_token):
-    token_payload = {
-        "grant_type": "refresh_token",
-        "client_id": AUTH0_CLIENT_ID,
-        "refresh_token": refresh_token,
-    }
-
-    token_response = requests.post(
-        f"https://{AUTH0_DOMAIN}/oauth/token", data=token_payload, timeout=30  # noqa
-    )
-    token_response.raise_for_status()
-    token_data = token_response.json()
-
-    save_token(token_data, TOKEN_PATH)
-
-
-def save_token(token_data, token_path):
-    with open(token_path, "w") as tf:
+    with open(TOKEN_PATH, "w") as tf:
         json.dump(token_data, tf)


### PR DESCRIPTION
### Description
Please explain the changes you made here.

I have replaced the `Client`'s `token` attribute with an auth class. This class intercepts requests, ensuring the appropriate headers are attached. When instantiated, it will look for a token file and use that. If this file doesnt exist, no auth will be available until the user logs in. When users excecute a query whilst no auth file is available and they have not logged in a `FileNotFoundError` is raised instructing them to login:

![image](https://github.com/transition-zero/feo-client/assets/58216420/47432de5-73f8-4213-8097-bad2dcff7d9a)


Additionally, the auth class will catch authentication errors due to expired access tokens and issue a refresh token request, updating the client's stored access token.

### Checklist
- [x] Dependencies install correctly in a clean environment and code executes;
- [ ] Test coverage extended; created tests fail without the change (if possible);
- [x] All tests passing;
- [x] Commits follow a type convention (e.g. https://gist.github.com/brianclements/841ea7bffdb01346392c#type);
- [x] Extended the README, documentation and/or docstrings, if necessary;
