### PR TITLE
[ENG-461] fix: project github links

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,10 +44,10 @@ geo = [
   ]
 
 [project.urls]  # Optional
-"Homepage" = "https://github.com/transitionzero/feo-client"
-"Bug Reports" = "https://github.com/transitionzero/feo-client/issues"
+"Homepage" = "https://github.com/transition-zero/feo-client"
+"Bug Reports" = "https://github.com/transition-zero/feo-client/issues"
 "Funding" = "https://transitionzero.org"
-"Source" = "https://github.com/transitionzero/feo-client"
+"Source" = "https://github.com/transition-zero/feo-client"
 
 # The following would provide a command line executable called `sample`
 # which executes the function `main` from this package when invoked.


### PR DESCRIPTION
### Description
Add a dash to the org name in our github links.

### Checklist
- [x] Dependencies install correctly in a clean environment and code executes;
- [x] Test coverage extended; created tests fail without the change (if possible);
- [x] All tests passing;
- [x] Commits follow a type convention (e.g. https://gist.github.com/brianclements/841ea7bffdb01346392c#type);
- [x] Extended the README, documentation and/or docstrings, if necessary;
