### PR TITLE
ENG-458-feat-technology-delete

### DIFF
--- a/feo/client/api/client.py
+++ b/feo/client/api/client.py
@@ -115,6 +115,9 @@ class Client:
     def post(self, *args, **kwargs):
         return self.httpx_client.post(*args, **kwargs)
 
+    def delete(self, *args, **kwargs):
+        return self.httpx_client.delete(*args, **kwargs)
+
     @classmethod
     def catch_errors(cls, r):
         r.raise_for_status()

--- a/feo/client/api/technologies.py
+++ b/feo/client/api/technologies.py
@@ -86,7 +86,7 @@ class TechnologyAPI(BaseAPI):
 
     def delete(self, slug: str):
         """
-        DELETE a technology from the API.
+        DELETE a technology via the API.
 
         Args:
             slug (str): The slug of the technology to delete.
@@ -96,6 +96,6 @@ class TechnologyAPI(BaseAPI):
             HTTPError: If the DELETE request fails. Note that if the
             error code is 401, this is likely due to invalid credentials.
         """
-        resp = self.client.delete(f"/technologies/{slug}")
+        resp = self.client.delete("/technologies", json={"slug": slug})
         resp.raise_for_status()
         return resp.json()

--- a/feo/client/api/technologies.py
+++ b/feo/client/api/technologies.py
@@ -83,3 +83,19 @@ class TechnologyAPI(BaseAPI):
         resp = self.client.post("/technologies", json=technology_data)
         resp.raise_for_status()
         return resp.json()
+
+    def delete(self, slug: str):
+        """
+        DELETE a technology from the API.
+
+        Args:
+            slug (str): The slug of the technology to delete.
+
+        Raises:
+            RefreshTokenError: If the refresh token is invalid.
+            HTTPError: If the DELETE request fails. Note that if the
+            error code is 401, this is likely due to invalid credentials.
+        """
+        resp = self.client.delete(f"/technologies/{slug}")
+        resp.raise_for_status()
+        return resp.json()

--- a/tests/CI/test_api_technology.py
+++ b/tests/CI/test_api_technology.py
@@ -68,3 +68,16 @@ def test_technology_post_http_error(technology_post_cases):
             "/technologies",
             json=params,
         )
+
+
+def test_technology_delete():
+    technology_slug = "test_slug"
+
+    with mock.patch.object(api.technologies.client, "delete") as mock_delete:
+        mock_response = mock.Mock()
+        mock_response.json.return_value = {"status": "success"}
+        mock_delete.return_value = mock_response
+
+        result = api.technologies.delete(slug=technology_slug)
+        assert result == {"status": "success"}
+        mock_delete.assert_called_once_with("/technologies", json={"slug": technology_slug})

--- a/tests/CI/test_technology.py
+++ b/tests/CI/test_technology.py
@@ -37,3 +37,8 @@ def test_technology_projections():
     assert len(gas_combined_cycle.projections) > 0
     record = gas_combined_cycle.projections.iloc[0].to_records()
     assert isinstance(record, Record)
+
+
+def test_technology_delete(technology):
+    technology.delete()
+    assert Technology.from_id("coal") is None

--- a/tests/CI/test_technology.py
+++ b/tests/CI/test_technology.py
@@ -37,8 +37,3 @@ def test_technology_projections():
     assert len(gas_combined_cycle.projections) > 0
     record = gas_combined_cycle.projections.iloc[0].to_records()
     assert isinstance(record, Record)
-
-
-def test_technology_delete(technology):
-    technology.delete()
-    assert Technology.from_id("coal") is None


### PR DESCRIPTION
### Description
We have a route for deleting technology data [here](https://github.com/transition-zero/feo-model-results/blob/1c9cecea2548236ab88a8617f1667ab317eba848/transitionzero/model_results/controllers/technologies.py#L160). This PR is to add functionality to use this delete route.

### Checklist
- [x] Dependencies install correctly in a clean environment and code executes;
- [x] Test coverage extended; created tests fail without the change (if possible);
- [x] All tests passing;
- [x] Commits follow a type convention (e.g. https://gist.github.com/brianclements/841ea7bffdb01346392c#type);
- [x] Extended the README, documentation and/or docstrings, if necessary;
