### PR TITLE
feat: Nix development shell

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,7 @@ dmypy.json
 # VSCode settings
 .vscode/
 .dev.*
+
+# Nix
+.direnv/
+result

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ If you are simply looking to start working with the codebase, navigate to the Gi
 
 Feel free to ask questions on the mailing list or on Slack.
 
-As contributors and maintainers to this project, you are expected to abide by TransitionZero's code of conduct. More information can be found at: Contributor Code of Conduct
+As contributors and maintainers to this project, you are expected to abide by TransitionZero's code of conduct. More information can be found in the [Code of Conduct](CODE-OF-CONDUCT.md).
 
 ## Installing dev dependencies
 
@@ -41,3 +41,34 @@ pytest
 ```
 
 After having made changes in the codebase, run `pip install ".[dev]"` to pick them up in the tests.
+
+## Nix
+
+We have provided a [nix](https://nixos.org/)
+[flake](https://nixos.wiki/wiki/Flakes) if you wish to use it.
+
+We make use of [pyproject.nix](https://github.com/nix-community/pyproject.nix)
+to grab the dependencies from the [pyproject.toml](./pyproject.toml) file, and
+we enable all optional dependencies.
+
+There are a couple of quirks:
+
+1. pyproject.nix does make the `project.scripts` binaries available in the
+   shell: <https://github.com/nix-community/pyproject.nix/issues/67>
+   - To get the binary, you may run `nix build .` and find it at
+   `./result/bin/feo`.
+2. The dynamic version doesn't play well with Nix for two reasons:
+  - Nix needs a static version for building the package, so we just set it to
+     `0.0.0`,
+  - pyproject.nix does not actually _install_ the package, so importlib is
+     unable to find it's version: <https://github.com/nix-community/pyproject.nix/issues/66>
+
+Note that for the pre-commit hooks, one might ideally use
+[pre-commit-hooks.nix](https://github.com/cachix/pre-commit-hooks.nix) but
+this requires you to define and configure the hooks in the flake.nix file,
+which then generates the `.pre-commit-config.yaml` file; i.e. it requires nix
+to make changes to the hooks; but we want nix to be optional, so we leave it
+as-is for now.
+
+As a result, you should run `pre-commit install` to install the hooks, once in
+the dev shell.

--- a/feo/client/__init__.py
+++ b/feo/client/__init__.py
@@ -28,7 +28,7 @@
 """
 
 
-from importlib.metadata import version
+from importlib.metadata import PackageNotFoundError, version
 
 from feo.client.asset import Asset, AssetCollection
 from feo.client.geospatial import Features, Geometry
@@ -46,7 +46,10 @@ Source.model_rebuild()
 Asset.model_rebuild()
 Node.model_rebuild()
 
-__version__ = version("feo-client")
+try:
+    __version__ = version("feo-client")
+except PackageNotFoundError:
+    pass
 
 __all__ = [
     "Node",

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,128 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1709126324,
+        "narHash": "sha256-q6EQdSeUZOG26WelxqkmR7kArjgWCdw5sfJVHPH/7j8=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "d465f4819400de7c8d874d50b982301f28a84605",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "mdbook-nixdoc": {
+      "inputs": {
+        "nix-github-actions": [
+          "pyproject-nix",
+          "nix-github-actions"
+        ],
+        "nixpkgs": [
+          "pyproject-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1708395692,
+        "narHash": "sha256-smf0VmxGbjJDZqKvxxG3ZVqubgbVwAWG26wPo+BT/A0=",
+        "owner": "adisbladis",
+        "repo": "mdbook-nixdoc",
+        "rev": "d6a71b114b9221c0b4f20d31b81766d072cc26be",
+        "type": "github"
+      },
+      "original": {
+        "owner": "adisbladis",
+        "repo": "mdbook-nixdoc",
+        "type": "github"
+      }
+    },
+    "nix-github-actions": {
+      "inputs": {
+        "nixpkgs": [
+          "pyproject-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1703863825,
+        "narHash": "sha256-rXwqjtwiGKJheXB43ybM8NwWB8rO2dSRrEqes0S7F5Y=",
+        "owner": "nix-community",
+        "repo": "nix-github-actions",
+        "rev": "5163432afc817cf8bd1f031418d1869e4c9d5547",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nix-github-actions",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1709780214,
+        "narHash": "sha256-p4iDKdveHMhfGAlpxmkCtfQO3WRzmlD11aIcThwPqhk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f945939fd679284d736112d3d5410eb867f3b31c",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "pyproject-nix": {
+      "inputs": {
+        "mdbook-nixdoc": "mdbook-nixdoc",
+        "nix-github-actions": "nix-github-actions",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709886419,
+        "narHash": "sha256-qXZsmegy0W0hn9yxYQFin1jZB3ikmBWXyBDQx1AqEQ4=",
+        "owner": "nix-community",
+        "repo": "pyproject.nix",
+        "rev": "2841577401c77106150b98bcb3a30510cb6c652a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "pyproject.nix",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "pyproject-nix": "pyproject-nix"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,80 @@
+{
+  inputs.pyproject-nix = {
+    url = "github:nix-community/pyproject.nix";
+    inputs.nixpkgs.follows = "nixpkgs";
+  };
+  inputs.flake-utils.url = "github:numtide/flake-utils";
+
+  outputs =
+    { nixpkgs
+    , pyproject-nix
+    , flake-utils
+    , ...
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        inherit (nixpkgs) lib;
+        project = pyproject-nix.lib.project.loadPyproject {
+          projectRoot = ./.;
+        };
+        pkgs = import nixpkgs { inherit system; };
+        python = pkgs.python3.override {
+          packageOverrides = self: super: {
+            # Note: `pre-commit` is not a package under pythonPackages in
+            # nixpkgs; it is a top-level package. So we simply drop it here as
+            # a python dependency (it's not used in python _code_ ever), and
+            # require it in the devShell as a simple package.
+            pre-commit = builtins.null;
+          };
+        };
+      in
+      rec
+      {
+        formatter = pkgs.nixpkgs-fmt;
+        devShells.default =
+          let
+            arg =
+              project.renderers.withPackages
+                {
+                  inherit python;
+                  # Install all dependencies; it's probably what we want.
+                  extras = [ "geo" "dev" ];
+                };
+            pythonEnv = python.withPackages arg;
+          in
+          pkgs.mkShell {
+            packages = [
+              pythonEnv
+              pkgs.pre-commit
+            ];
+
+            # We set the Python-path explicitly to this directory so that
+            # `pytest` works the same as `python -m pytest` (i.e. it can find
+            # the "tests" module.)
+            shellHook = "
+              export PYTHONPATH=${builtins.toString ./.}
+            ";
+          };
+
+        packages.default =
+          let
+            attrs = project.renderers.buildPythonPackage
+              {
+                inherit python;
+                extras = [ "geo" ];
+              };
+          in
+          python.pkgs.buildPythonPackage (attrs // {
+            # Note: The version is computed dynamically; but this is not
+            # possible in Nix; it would require the version to be in a file in
+            # source control.
+            #
+            # However, we are not using this binary as a distribution, more
+            # just as a way to obtain a local binary for development; so we
+            # just hard-code the version.
+            version = "0.0.0";
+          });
+      }
+    );
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ geo = [
 "Funding" = "https://transitionzero.org"
 "Source" = "https://github.com/transition-zero/feo-client"
 
-# The following would provide a command line executable called `sample`
+# The following would provide a command line executable called `feo`
 # which executes the function `main` from this package when invoked.
 [project.scripts]  # Optional
 feo = "feo.client.cli:main"


### PR DESCRIPTION
### Description

This adds a simple Nix development shell based on [pyproject.nix](https://github.com/nix-community/pyproject.nix/) using [direnv](https://direnv.net/).

I've added this to allow development on NixOS/nix.

Note that there are a couple of quirks that, perhaps, are solvable, and I've opened as issues:
- https://github.com/nix-community/pyproject.nix/issues/67
- https://github.com/nix-community/pyproject.nix/issues/66

I also made some very small fixes in a couple of spots I noticed them; a missing link here or typo.

The main code change I had to make was to allow setting the `__version__` attribute to fail; which is does in the nix environment. Hopefully this isn't too controversial as it should only affect nix. I opened https://github.com/nix-community/pyproject.nix/issues/66 to track this and hopefully there is an answer. As a bit of trivia, it might be more idiomatic (for nix, anyway) to have the version as a hard-coded file in the repository; then at least the nix package installation could also be made correct (see the `flake.nix` for a comment explaining this situation.)

For Nix people, note that I opted not to use [pre-commit-hooks.nix](https://github.com/cachix/pre-commit-hooks.nix) (because it would mean moving the configuration of the hooks to Nix, which basically means you'd _need_ to use nix to change them, which I didn't want to require), so you will need to run `pre-commit install` when entering the shell for the first time.

Let me know if there are any concerns/thoughts/extra things to do :)

If you wish to try this yourself, you would need to simply:
1. Install nix-the-package manager - https://nixos.org/download.html
2. From the folder with the flake run `nix develop`
3. Confirm it works by running `pytest` from the resulting shell! :)

Potential extensions:
- [ ] Set up CI to test that the devShell works.
    - I'm happy to do this we wish; it's probably a good idea, to make sure it doesn't break based at some point from some non-nix change, or otherwise. But, if it _does_ break on a non-nix change it will require someone with a bit of nix experience to fix.


### Checklist
- [x] Dependencies install correctly in a clean environment and code executes;
- [x] Test coverage extended; created tests fail without the change (if possible);
- [x] All tests passing;
- [x] Commits follow a type convention (e.g. https://gist.github.com/brianclements/841ea7bffdb01346392c#type);
- [x] Extended the README, documentation and/or docstrings, if necessary;